### PR TITLE
Add support for cloud providers API

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,6 +80,8 @@ pipeline:
     qt-5.9:
         image: nextcloudci/client-5.9:latest
         commands:
+            - apt-get install -y python3 python3-pip ninja-build
+            - /usr/bin/pip3 install meson
             # Install QtKeyChain
             - /bin/bash -c "
               source /opt/qt59/bin/qt59-env.sh &&
@@ -92,6 +94,16 @@ pipeline:
               cmake ../ &&
               make &&
               make install"
+            # Install libcloudproviders
+            - /bin/bash -c "
+              source /opt/qt59/bin/qt59-env.sh &&
+              cd /tmp &&
+              git clone https://github.com/juliushaertl/libcloudproviders.git &&
+              cd libcloudproviders &&
+              meson build &&
+              cd build &&
+              ninja &&
+              ninja install"
             # Build client
             - /bin/bash -c "
               source /opt/qt59/bin/qt59-env.sh &&

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,9 @@ if (USE_OUR_OWN_SQLITE3)
 endif()
 
 find_package(ZLIB)
+find_package(Glib)
+find_package(Gio)
+find_package(Libcloudproviders)
 
 if (NOT DEFINED APPLICATION_ICON_NAME)
     set(APPLICATION_ICON_NAME ${APPLICATION_SHORTNAME})

--- a/cmake/modules/FindGLib2.cmake
+++ b/cmake/modules/FindGLib2.cmake
@@ -1,0 +1,36 @@
+# FindGLib2.cmake
+
+# GLib2_FOUND - System has GLib2
+# GLib2_INCLUDES - The GLib2 include directories
+# GLib2_LIBRARIES - The libraries needed to use GLib2
+# GLib2_DEFINITIONS - Compiler switches required for using GLib2
+
+find_package(PkgConfig)
+pkg_check_modules(PC_GLib2 QUIET glib-2.0)
+set(GLib2_DEFINITIONS ${PC_GLib2_CFLAGS_OTHER})
+
+find_path(GLib2_INCLUDE_DIR
+          NAMES glib.h glib-object.h
+          HINTS ${PC_GLib2_INCLUDEDIR} ${PC_GLib2_INCLUDE_DIRS}
+          PATH_SUFFIXES glib-2.0)
+find_path(GLIBCONFIG_INCLUDE_DIR
+          NAMES glibconfig.h
+          HINTS ${PC_LIBDIR} ${PC_LIBRARY_DIRS} ${_GLib2_LIBRARY_DIR}
+                ${PC_GLib2_INCLUDEDIR} ${PC_GLib2_INCLUDE_DIRS}
+                ${CMAKE_EXTRA_INCLUDES} ${CMAKE_EXTRA_LIBRARIES} 
+          PATH_SUFFIXES glib-2.0 glib-2.0/include)
+list(APPEND GLib2_INCLUDE_DIR ${GLIBCONFIG_INCLUDE_DIR})
+#message (STATUS "GLib2_INCLUDES: ${GLib2_INCLUDE_DIR}")
+
+find_library(GLib2_LIBRARY
+             NAMES glib-2.0 libglib-2.0
+             HINTS ${PC_GLib2_LIBDIR} ${PC_GLib2_LIBRARY_DIRS})
+
+set(GLib2_LIBRARIES ${GLib2_LIBRARY})
+set(GLib2_INCLUDE_DIRS ${GLib2_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GLib2 DEFAULT_MSG
+                                  GLib2_LIBRARY GLib2_INCLUDE_DIR)
+
+mark_as_advanced(GLib2_INCLUDE_DIR GLib2_LIBRARY)

--- a/cmake/modules/FindGio.cmake
+++ b/cmake/modules/FindGio.cmake
@@ -1,0 +1,61 @@
+# - Try to find Gio
+# Once done this will define
+#
+#  GIO_FOUND - system has Gio
+#  GIO_INCLUDE_DIR - the Gio include directory
+#  GIO_LIBRARIES - the libraries needed to use Gio
+#  GIO_DEFINITIONS - Compiler switches required for using Gio
+
+
+IF (GIO_INCLUDE_DIR AND GIO_LIBRARIES)
+   # in cache already
+   SET(Gio_FIND_QUIETLY TRUE)
+ELSE (GIO_INCLUDE_DIR AND GIO_LIBRARIES)
+   SET(Gio_FIND_QUIETLY FALSE)
+ENDIF (GIO_INCLUDE_DIR AND GIO_LIBRARIES)
+
+IF (NOT WIN32)
+   # use pkg-config to get the directories and then use these values
+   # in the FIND_PATH() and FIND_LIBRARY() calls
+   FIND_PACKAGE(PkgConfig)
+   PKG_CHECK_MODULES(PC_GIO gio-2.0)
+   #MESSAGE(STATUS "DEBUG: Gio include directory = ${GIO_INCLUDE_DIRS}")
+   #MESSAGE(STATUS "DEBUG: Gio link directory = ${GIO_LIBRARY_DIRS}")
+   #MESSAGE(STATUS "DEBUG: Gio CFlags = ${GIO_CFLAGS}")
+   SET(GIO_DEFINITIONS ${PC_GIO_CFLAGS_OTHER})
+ENDIF (NOT WIN32)
+
+FIND_PATH(GIO_INCLUDE_DIR gio.h
+   PATHS
+   ${PC_GIO_INCLUDEDIR}
+   ${PC_GIO_INCLUDE_DIRS}
+   PATH_SUFFIXES glib-2.0/gio/
+   )
+
+FIND_LIBRARY(_GioLibs NAMES gio-2.0 libgio-2.0
+   PATHS
+   ${PC_GIO_LIBDIR}
+   ${PC_GIO_LIBRARY_DIRS}
+   )
+
+SET( GIO_LIBRARIES ${_GioLibs} )
+SET( GIO_INCLUDE_DIRS ${GIO_INCLUDE_DIR} )
+
+IF (GIO_INCLUDE_DIR AND GIO_LIBRARIES)
+   SET(GIO_FOUND TRUE)
+ELSE (GIO_INCLUDE_DIR AND GIO_LIBRARIES)
+   SET(GIO_FOUND FALSE)
+ENDIF (GIO_INCLUDE_DIR AND GIO_LIBRARIES)
+
+IF (GIO_FOUND)
+   IF (NOT Gio_FIND_QUIETLY)
+      MESSAGE(STATUS "Found Gio libraries: ${GIO_LIBRARIES}")
+      MESSAGE(STATUS "Found Gio includes : ${GIO_INCLUDE_DIR}")
+   ENDIF (NOT Gio_FIND_QUIETLY)
+ELSE (GIO_FOUND)
+    IF (Gio_FIND_REQUIRED)
+      MESSAGE(STATUS "Could NOT find Gio")
+    ENDIF(Gio_FIND_REQUIRED)
+ENDIF (GIO_FOUND)
+
+MARK_AS_ADVANCED(GIO_INCLUDE_DIR _GioLibs)

--- a/cmake/modules/FindLibcloudproviders.cmake
+++ b/cmake/modules/FindLibcloudproviders.cmake
@@ -1,0 +1,31 @@
+# FindLibcloudproviders.cmake
+
+# LIBCLOUDPROVIDERS_FOUND - System has LIBCLOUDPROVIDERS
+# LIBCLOUDPROVIDERS_INCLUDES - The LIBCLOUDPROVIDERS include directories
+# LIBCLOUDPROVIDERS_LIBRARIES - The libraries needed to use LIBCLOUDPROVIDERS
+# LIBCLOUDPROVIDERS_DEFINITIONS - Compiler switches required for using LIBCLOUDPROVIDERS
+
+include(FindPackageHandleStandardArgs)
+find_package(PkgConfig)
+
+find_path(LIBCLOUDPROVIDERS_INCLUDE_DIR
+    NAMES cloudprovider.h cloudproviderproxy.h
+    PATH_SUFFIXES cloudproviders
+    PATHS
+    /usr/lib
+    /usr/lib/${CMAKE_ARCH_TRIPLET}
+    /usr/local/lib
+    /opt/local/lib
+    ${CMAKE_LIBRARY_PATH}
+    ${CMAKE_INSTALL_PREFIX}/lib
+    /home/jus/jhbuild/install/include
+)
+find_library(LIBCLOUDPROVIDERS_LIBRARY
+    NAMES libcloudproviders.so
+    PATHS /home/jus/jhbuild/install/lib
+)
+message ( ${LIBCLOUDPROVIDERS_LIBRARY} )
+message ( ${LIBCLOUDPROVIDERS_INCLUDE_DIR} )
+set(LIBCLOUDPROVIDERS_LIBRARIES ${LIBCLOUDPROVIDERS_LIBRARY})
+set(LIBCLOUDPROVIDERS_INCLUDE_DIRS ${LIBCLOUDPROVIDERS_INCLUDE_DIR})
+

--- a/cmake/modules/FindLibcloudproviders.cmake
+++ b/cmake/modules/FindLibcloudproviders.cmake
@@ -18,7 +18,6 @@ find_path(LIBCLOUDPROVIDERS_INCLUDE_DIR
     /opt/local/lib
     ${CMAKE_LIBRARY_PATH}
     ${CMAKE_INSTALL_PREFIX}/lib
-    /home/jus/jhbuild/install/include
 )
 find_library(LIBCLOUDPROVIDERS_LIBRARY
     NAMES libcloudproviders.so

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -180,7 +180,7 @@ set(3rdparty_INC
 
 include_directories(${3rdparty_INC})
 
-IF( NOT WIN32 AND NOT APPLE AND WITH_DBUS)
+IF( NOT WIN32 AND NOT APPLE AND WITH_DBUS AND LIBCLOUDPROVIDERS_FOUND)
     add_definitions(-DWITH_LIBCLOUDPROVIDERS)
     set(client_SRCS ${client_SRCS} cloudproviders/cloudprovidermanager.cpp)
     set(client_SRCS ${client_SRCS} cloudproviders/cloudproviderwrapper.cpp)
@@ -312,7 +312,7 @@ target_link_libraries( ${APPLICATION_EXECUTABLE} ${QT_LIBRARIES} )
 target_link_libraries( ${APPLICATION_EXECUTABLE} ${synclib_NAME} )
 target_link_libraries( ${APPLICATION_EXECUTABLE} updater )
 target_link_libraries( ${APPLICATION_EXECUTABLE} ${OS_SPECIFIC_LINK_LIBRARIES} )
-IF( NOT WIN32 AND NOT APPLE )
+IF( NOT WIN32 AND NOT APPLE AND LIBCLOUDPROVIDERS_FOUND)
     target_link_libraries( ${APPLICATION_EXECUTABLE} ${GLIB_LDFLAGS} ${GIO_LDFLAGS} )
     target_link_libraries( ${APPLICATION_EXECUTABLE} ${LIBCLOUDPROVIDERS_LIBRARIES} )
 ENDIF()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -180,6 +180,19 @@ set(3rdparty_INC
 
 include_directories(${3rdparty_INC})
 
+IF( NOT WIN32 AND NOT APPLE AND WITH_DBUS)
+    add_definitions(-DWITH_LIBCLOUDPROVIDERS)
+    set(client_SRCS ${client_SRCS} cloudproviders/cloudprovidermanager.cpp)
+    set(client_SRCS ${client_SRCS} cloudproviders/cloudproviderwrapper.cpp)
+
+    include_directories(${GLIB_INCLUDE_DIRS})
+    include_directories(${GIO_INCLUDE_DIRS})
+    include_directories(${LIBCLOUDPROVIDERS_INCLUDE_DIRS})
+ENDIF()
+
+
+
+
 # csync is required.
 include_directories(${CMAKE_SOURCE_DIR}/csync/src
                     ${CMAKE_BINARY_DIR}/csync
@@ -299,6 +312,11 @@ target_link_libraries( ${APPLICATION_EXECUTABLE} ${QT_LIBRARIES} )
 target_link_libraries( ${APPLICATION_EXECUTABLE} ${synclib_NAME} )
 target_link_libraries( ${APPLICATION_EXECUTABLE} updater )
 target_link_libraries( ${APPLICATION_EXECUTABLE} ${OS_SPECIFIC_LINK_LIBRARIES} )
+IF( NOT WIN32 AND NOT APPLE )
+    target_link_libraries( ${APPLICATION_EXECUTABLE} ${GLIB_LDFLAGS} ${GIO_LDFLAGS} )
+    target_link_libraries( ${APPLICATION_EXECUTABLE} ${LIBCLOUDPROVIDERS_LIBRARIES} )
+ENDIF()
+
 
 if(WITH_CRASHREPORTER)
     target_link_libraries( ${APPLICATION_EXECUTABLE} crashreporter-handler)

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -197,6 +197,9 @@ Application::Application(int &argc, char **argv)
     if (_showLogWindow) {
         _gui->slotToggleLogBrowser(); // _showLogWindow is set in parseOptions.
     }
+#if WITH_LIBCLOUDPROVIDERS
+    _gui->setupCloudProviders();
+#endif
 
     // Enable word wrapping of QInputDialog (#4197)
     setStyleSheet("QInputDialog QLabel { qproperty-wordWrap:1; }");

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -393,6 +393,18 @@ void Application::slotParseMessage(const QString &msg, QObject *)
             return;
         }
         showSettingsDialog();
+    } else if (msg.startsWith(QLatin1String("MSG_SHOWWIZARD"))) {
+        qCInfo(lcApplication) << "Running for" << _startedAt.elapsed() / 1000.0 << "sec";
+        if (_startedAt.elapsed() < 10 * 1000) {
+            // This call is mirrored with the one in int main()
+            qCWarning(lcApplication) << "Ignoring MSG_SHOWWIZARD, possibly double-invocation of client via session restore and auto start";
+            return;
+        }
+        if (AccountManager::instance()->accounts().isEmpty()) {
+            // allow to add a new account if there is non any more. Always think
+            // about single account theming!
+            OwncloudSetupWizard::runWizard(this, SLOT(slotownCloudWizardDone(int)));
+        }
     }
 }
 

--- a/src/gui/cloudproviders/cloudprovidermanager.cpp
+++ b/src/gui/cloudproviders/cloudprovidermanager.cpp
@@ -1,0 +1,85 @@
+extern "C" {
+    #include <glib.h>
+    #include <gio.h>
+    #include <cloudprovider.h>
+}
+#include "cloudproviderwrapper.h"
+#include "cloudprovidermanager.h"
+#include "config.h"
+#include "folderman.h"
+#include "accountstate.h"
+#include "account.h"
+
+CloudProvider *_cloudProvider;
+GDBusConnection *_connection;
+
+void on_bus_acquired (GDBusConnection *connection, const gchar *name, gpointer user_data)
+{
+  QString orgName = QString(APPLICATION_VENDOR).replace(" ", "").toLower();
+  QString appName = QString(APPLICATION_SHORTNAME).replace(" ", "").toLower();
+  QString busName = "org." + orgName + "." + appName;
+  QString objectName = "/org/" + orgName + "/" + appName;
+
+  CloudProviderManager *self = static_cast<CloudProviderManager*>(user_data);
+  _cloudProvider = cloud_provider_new(connection, busName.toAscii().data(), objectName.toAscii().data());
+  _connection = connection;
+  self->registerSignals();
+}
+
+static void on_name_acquired (GDBusConnection *connection, const gchar *name, gpointer user_data)
+{
+    (void)(connection);
+    (void)(name);
+    (void)(user_data);
+}
+
+static void on_name_lost (GDBusConnection *connection, const gchar *name, gpointer user_data)
+{
+    (void)connection;
+    (void)name;
+    (void)user_data;
+    g_object_unref(_cloudProvider);
+}
+
+void CloudProviderManager::registerSignals()
+{
+    OCC::FolderMan *folderManager = OCC::FolderMan::instance();
+    connect(folderManager, SIGNAL(folderListChanged(const Folder::Map &)), SLOT(slotFolderListChanged(const Folder::Map &)));
+    slotFolderListChanged(folderManager->map());
+}
+
+CloudProviderManager::CloudProviderManager(QObject *parent) : QObject(parent)
+{
+    _map = new QMap<QString, CloudProviderWrapper*>();
+    QString orgName = QString(APPLICATION_VENDOR).replace(" ", "").toLower();
+    QString appName = QString(APPLICATION_SHORTNAME).replace(" ", "").toLower();
+    QString busName = "org." + orgName + "." + appName;
+    g_bus_own_name (G_BUS_TYPE_SESSION,
+                    busName.toAscii().data(),
+                    G_BUS_NAME_OWNER_FLAGS_NONE,
+                    on_bus_acquired, on_name_acquired, on_name_lost,
+                    this, NULL);
+}
+
+void CloudProviderManager::slotFolderListChanged(const Folder::Map &folderMap)
+{
+    QMapIterator<QString, CloudProviderWrapper*> i(*_map);
+    while (i.hasNext()) {
+        i.next();
+        if (!folderMap.contains(i.key())) {
+            gchar *accountName = i.value()->accountName();
+            cloud_provider_unexport_account(_cloudProvider, accountName);
+            _map->remove(i.key());
+        }
+    }
+
+    Folder::MapIterator j(folderMap);
+    while (j.hasNext()) {
+        j.next();
+        if (!_map->contains(j.key())) {
+            CloudProviderWrapper *cpo = new CloudProviderWrapper(this, j.value(), _cloudProvider);
+            _map->insert(j.key(), cpo);
+        }
+    }
+    cloud_provider_export_objects (_cloudProvider);
+}

--- a/src/gui/cloudproviders/cloudprovidermanager.cpp
+++ b/src/gui/cloudproviders/cloudprovidermanager.cpp
@@ -15,15 +15,16 @@ GDBusConnection *_connection;
 
 void on_bus_acquired (GDBusConnection *connection, const gchar *name, gpointer user_data)
 {
-  QString orgName = QString(APPLICATION_VENDOR).replace(" ", "").toLower();
-  QString appName = QString(APPLICATION_SHORTNAME).replace(" ", "").toLower();
-  QString busName = "org." + orgName + "." + appName;
-  QString objectName = "/org/" + orgName + "/" + appName;
+    (void)(name);
+    QString orgName = QString(APPLICATION_VENDOR).replace(" ", "").toLower();
+    QString appName = QString(APPLICATION_SHORTNAME).replace(" ", "").toLower();
+    QString busName = "org." + orgName + "." + appName;
+    QString objectName = "/org/" + orgName + "/" + appName;
 
-  CloudProviderManager *self = static_cast<CloudProviderManager*>(user_data);
-  _cloudProvider = cloud_provider_new(connection, busName.toAscii().data(), objectName.toAscii().data());
-  _connection = connection;
-  self->registerSignals();
+    CloudProviderManager *self = static_cast<CloudProviderManager*>(user_data);
+    _cloudProvider = cloud_provider_new(connection, busName.toAscii().data(), objectName.toAscii().data());
+    _connection = connection;
+    self->registerSignals();
 }
 
 static void on_name_acquired (GDBusConnection *connection, const gchar *name, gpointer user_data)

--- a/src/gui/cloudproviders/cloudprovidermanager.h
+++ b/src/gui/cloudproviders/cloudprovidermanager.h
@@ -1,0 +1,30 @@
+#ifndef CLOUDPROVIDERMANAGER_H
+#define CLOUDPROVIDERMANAGER_H
+
+#include <QObject>
+#include "dbus_types.h"
+#include "folder.h"
+
+using namespace OCC;
+
+class CloudProviderWrapper;
+
+class CloudProviderManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit CloudProviderManager(QObject *parent = nullptr);
+    void getMenuModel();
+    void registerSignals();
+
+signals:
+    void InterfacesAdded(const QDBusObjectPath &object, InterfaceMap &interfaces);
+
+public slots:
+    void slotFolderListChanged(const Folder::Map &folderMap);
+
+private:
+    QMap<QString, CloudProviderWrapper*> *_map;
+};
+
+#endif // CLOUDPROVIDERMANAGER_H

--- a/src/gui/cloudproviders/cloudprovidermanager.h
+++ b/src/gui/cloudproviders/cloudprovidermanager.h
@@ -2,7 +2,6 @@
 #define CLOUDPROVIDERMANAGER_H
 
 #include <QObject>
-#include "dbus_types.h"
 #include "folder.h"
 
 using namespace OCC;
@@ -14,11 +13,9 @@ class CloudProviderManager : public QObject
     Q_OBJECT
 public:
     explicit CloudProviderManager(QObject *parent = nullptr);
-    void getMenuModel();
     void registerSignals();
 
 signals:
-    void InterfacesAdded(const QDBusObjectPath &object, InterfaceMap &interfaces);
 
 public slots:
     void slotFolderListChanged(const Folder::Map &folderMap);

--- a/src/gui/cloudproviders/cloudproviderwrapper.cpp
+++ b/src/gui/cloudproviders/cloudproviderwrapper.cpp
@@ -1,0 +1,366 @@
+extern "C" {
+#include <glib.h>
+#include <gio.h>
+#include <cloudprovider.h>
+}
+
+#include "cloudproviderwrapper.h"
+#include <account.h>
+#include <folder.h>
+#include <accountstate.h>
+#include <QDesktopServices>
+#include "openfilemanager.h"
+#include "owncloudgui.h"
+#include "application.h"
+
+using namespace OCC;
+
+static gchar* qstring_to_gchar(QString string)
+{
+    return string.toUtf8().data();
+}
+
+static void
+on_get_name (CloudProviderAccount1 *cloud_provider, GDBusMethodInvocation *invocation, gpointer user_data)
+{
+    (void)(cloud_provider);
+    CloudProviderWrapper *self = static_cast<CloudProviderWrapper*>(user_data);
+    g_dbus_method_invocation_return_value (invocation, g_variant_new ("(s)", self->name));
+}
+
+static void
+on_get_icon (CloudProviderAccount1 *cloud_provider, GDBusMethodInvocation *invocation, gpointer user_data)
+{
+    (void)(cloud_provider);
+    CloudProviderWrapper *self = static_cast<CloudProviderWrapper*>(user_data);
+    g_dbus_method_invocation_return_value (invocation, g_variant_new ("(v)", g_icon_serialize(G_ICON(self->icon))));
+}
+
+static void
+on_get_path (CloudProviderAccount1 *cloud_provider, GDBusMethodInvocation *invocation, gpointer user_data)
+{
+    (void)(cloud_provider);
+    CloudProviderWrapper *self = static_cast<CloudProviderWrapper*>(user_data);
+    g_dbus_method_invocation_return_value (invocation, g_variant_new ("(s)", self->path));
+}
+
+static void
+on_get_status (CloudProviderAccount1 *cloud_provider, GDBusMethodInvocation *invocation, gpointer user_data)
+{
+    (void)(cloud_provider);
+    CloudProviderWrapper *self = static_cast<CloudProviderWrapper*>(user_data);
+    g_dbus_method_invocation_return_value (invocation, g_variant_new ("(i)", self->status));
+}
+
+static void
+on_get_status_details (CloudProviderAccount1 *cloud_provider, GDBusMethodInvocation *invocation, gpointer user_data)
+{
+    (void)(cloud_provider);
+    CloudProviderWrapper *self = static_cast<CloudProviderWrapper*>(user_data);
+    g_dbus_method_invocation_return_value (invocation, g_variant_new ("(s)", self->statusText()));
+}
+
+CloudProviderWrapper::CloudProviderWrapper(QObject *parent, Folder *folder, CloudProvider* cloudprovider) : QObject(parent)
+  , _folder(folder)
+{
+    _recentlyChanged = new QList<QString>();
+    _statusText = QString("");
+    this->path = g_strdup(qstring_to_gchar(folder->cleanPath()));
+    this->icon = g_icon_new_for_string("Nextcloud", NULL);
+    this->status = 1;
+    this->name = g_strdup(qstring_to_gchar(folder->shortGuiLocalPath()));
+    gchar *folderAlias = folder->alias().toUtf8().data();
+    gchar *accountId = folder->accountState()->account()->id().toUtf8().data();
+    _accountName = g_strdup_printf ("Account%sFolder%s", accountId, folderAlias);
+
+    _cloudProvider= CLOUD_PROVIDER(cloudprovider);
+    _cloudProviderAccount1 = cloud_provider_account1_skeleton_new();
+    g_signal_connect(_cloudProviderAccount1, "handle_get_name", G_CALLBACK (on_get_name), this);
+    g_signal_connect(_cloudProviderAccount1, "handle_get_icon", G_CALLBACK (on_get_icon), this);
+    g_signal_connect(_cloudProviderAccount1, "handle_get_path", G_CALLBACK (on_get_path), this);
+    g_signal_connect(_cloudProviderAccount1, "handle_get_status", G_CALLBACK (on_get_status), this);
+    g_signal_connect(_cloudProviderAccount1, "handle_get_status_details", G_CALLBACK (on_get_status_details), this);
+
+
+    cloud_provider_export_account(_cloudProvider, _accountName, _cloudProviderAccount1);
+    cloud_provider_export_menu (_cloudProvider, _accountName, getMenuModel());
+    cloud_provider_export_actions (_cloudProvider, _accountName, getActionGroup());
+
+
+    ProgressDispatcher *pd = ProgressDispatcher::instance();
+    connect(pd, SIGNAL(progressInfo(QString, ProgressInfo)), this, SLOT(slotUpdateProgress(QString, ProgressInfo)));
+
+    connect(this, SIGNAL(CloudProviderChanged()), this, SLOT(slotCloudProviderChanged()));
+    connect(_folder, SIGNAL(syncStarted()), this, SLOT(slotSyncStarted()));
+    connect(_folder, SIGNAL(syncFinished(SyncResult)), this, SLOT(slotSyncFinished(const SyncResult)));
+
+    //g_free(account_object_name);
+
+    emit CloudProviderChanged();
+}
+
+gchar* CloudProviderWrapper::accountName()
+{
+    return _accountName;
+}
+
+static bool shouldShowInRecentsMenu(const SyncFileItem &item)
+{
+    return !Progress::isIgnoredKind(item._status)
+        && item._instruction != CSYNC_INSTRUCTION_EVAL
+        && item._instruction != CSYNC_INSTRUCTION_NONE;
+}
+
+void CloudProviderWrapper::slotUpdateProgress(const QString &folder, const ProgressInfo &progress)
+{
+    // Only update progress for the current folder
+    Folder *f = FolderMan::instance()->folder(folder);
+    if (f != _folder)
+        return;
+
+    // Build recently changed files list
+    if (!progress._lastCompletedItem.isEmpty()
+        && shouldShowInRecentsMenu(progress._lastCompletedItem)) {
+        if (Progress::isWarningKind(progress._lastCompletedItem._status)) {
+            // display a warn icon if warnings happened.
+        }
+
+        QString kindStr = Progress::asResultString(progress._lastCompletedItem);
+        QString timeStr = QTime::currentTime().toString("hh:mm");
+        QString actionText = tr("%1 (%2, %3)").arg(progress._lastCompletedItem._file, kindStr, timeStr);
+        Folder *f = FolderMan::instance()->folder(folder);
+        if (f) {
+            QString fullPath = f->path() + '/' + progress._lastCompletedItem._file;
+            if (QFile(fullPath).exists()) {
+                // add action
+            }
+        }
+
+        if (_recentlyChanged->length() > 5)
+            _recentlyChanged->removeFirst();
+        _recentlyChanged->append(actionText);
+
+        // FIXME: rebuild menu
+    }
+
+    // Build status details text
+    if (!progress._currentDiscoveredFolder.isEmpty()) {
+        _statusText =  tr("Checking for changes in '%1'").arg(progress._currentDiscoveredFolder);
+        emit CloudProviderChanged();
+    } else if (progress.totalSize() == 0) {
+        quint64 currentFile = progress.currentFile();
+        quint64 totalFileCount = qMax(progress.totalFiles(), currentFile);
+        QString msg;
+        if (progress.trustEta()) {
+            msg = tr("Syncing %1 of %2  (%3 left)")
+                      .arg(currentFile)
+                      .arg(totalFileCount)
+                      .arg(Utility::durationToDescriptiveString2(progress.totalProgress().estimatedEta));
+        } else {
+            msg = tr("Syncing %1 of %2")
+                      .arg(currentFile)
+                      .arg(totalFileCount);
+        }
+        _statusText = msg;
+        emit CloudProviderChanged();
+    } else {
+        QString totalSizeStr = Utility::octetsToString(progress.totalSize());
+        QString msg;
+        if (progress.trustEta()) {
+            msg = tr("Syncing %1 (%2 left)")
+                      .arg(totalSizeStr, Utility::durationToDescriptiveString2(progress.totalProgress().estimatedEta));
+        } else {
+            msg = tr("Syncing %1")
+                      .arg(totalSizeStr);
+        }
+        msg = tr("Syncing %1 (%2 left)")
+                  .arg(totalSizeStr, Utility::durationToDescriptiveString2(progress.totalProgress().estimatedEta));
+        _statusText = msg;
+        emit CloudProviderChanged();
+    }
+
+    if (progress.isUpdatingEstimates()
+            && progress.completedFiles() >= progress.totalFiles()
+            && progress._currentDiscoveredFolder.isEmpty()) {
+            QTimer::singleShot(2000, this, SLOT(slotStatusUpdateIdle()));
+        }
+}
+
+void CloudProviderWrapper::slotStatusUpdateIdle()
+{
+    _statusText = tr("Up to date");
+    emit CloudProviderChanged();
+}
+
+
+gchar* CloudProviderWrapper::statusText()
+{
+    return _statusText.toUtf8().data();
+}
+
+
+Folder* CloudProviderWrapper::folder()
+{
+    return _folder;
+}
+
+void CloudProviderWrapper::slotCloudProviderChanged()
+{
+    cloud_provider_account1_emit_cloud_provider_changed(_cloudProviderAccount1);
+}
+
+
+void CloudProviderWrapper::slotSyncStarted()
+{
+    status = CLOUD_PROVIDER_STATUS_SYNCING;
+    emit CloudProviderChanged();
+}
+
+void CloudProviderWrapper::slotSyncFinished(const SyncResult &result)
+{
+    if (result.status() == result.Success)
+    {
+        status = CLOUD_PROVIDER_STATUS_IDLE;
+        emit CloudProviderChanged();
+        return;
+    }
+    status = CLOUD_PROVIDER_STATUS_ERROR;
+    emit CloudProviderChanged();
+}
+
+GMenuModel* CloudProviderWrapper::getMenuModel() {
+
+    GMenu* section;
+    GMenu* mainMenu;
+    GMenuItem* item;
+
+    mainMenu = g_menu_new();
+
+    section = g_menu_new();
+    //item = g_menu_item_new(qstring_to_gchar(_folder->syncResult().statusString()), NULL);
+    //g_menu_append_item(section, item);
+    item = g_menu_item_new("Open website", "cloudprovider.openwebsite");
+    g_menu_append_item(section, item);
+    g_menu_append_section(mainMenu, NULL, G_MENU_MODEL(section));
+
+    // Recently changed files menu
+    GMenu* recentMenu = g_menu_new();
+    section = g_menu_new();
+
+    // FIXME: use real data
+    item = g_menu_item_new("file.pdf", "cloudprovider.openfolder");
+    g_menu_append_item(recentMenu, item);
+    item = g_menu_item_new("file.pdf", "cloudprovider.openfolder");
+    g_menu_append_item(recentMenu, item);
+    item = g_menu_item_new("file.pdf", "cloudprovider.openfolder");
+    g_menu_append_item(recentMenu, item);
+    item = g_menu_item_new("file.pdf", "cloudprovider.openfolder");
+    g_menu_append_item(recentMenu, item);
+
+    item = g_menu_item_new_submenu("Recently changed", G_MENU_MODEL(recentMenu));
+    g_menu_append_item(section, item);
+    g_menu_append_section(mainMenu, NULL, G_MENU_MODEL(section));
+
+    // Additional items
+    section = g_menu_new();
+    item = g_menu_item_new("Pause synchronization", "cloudprovider.pause");
+    g_menu_append_item(section, item);
+
+    g_menu_append_section(mainMenu, NULL, G_MENU_MODEL(section));
+
+    section = g_menu_new();
+    item = g_menu_item_new("Help", "cloudprovider.openhelp");
+    g_menu_append_item(section, item);
+    item = g_menu_item_new("Settings", "cloudprovider.opensettings");
+    g_menu_append_item(section, item);
+    item = g_menu_item_new("Log out", "cloudprovider.logout");
+    g_menu_append_item(section, item);
+    item = g_menu_item_new("Quit sync client", "cloudprovider.quit");
+    g_menu_append_item(section, item);
+    g_menu_append_section(mainMenu, NULL, G_MENU_MODEL(section));
+
+    return G_MENU_MODEL(mainMenu);
+}
+
+static void
+activate_action_open (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+{
+    (void)(parameter);
+    const gchar *name = g_action_get_name(G_ACTION(action));
+    CloudProviderWrapper *self = static_cast<CloudProviderWrapper*>(user_data);
+    ownCloudGui *gui = qobject_cast<ownCloudGui*>(self->parent()->parent());
+
+    if(g_str_equal(name, "openhelp")) {
+        gui->slotHelp();
+    }
+
+    if(g_str_equal(name, "opensettings")) {
+            gui->slotShowSettings();
+        }
+
+    if(g_str_equal(name, "openwebsite")) {
+        QDesktopServices::openUrl(self->folder()->accountState()->account()->url());
+    }
+
+    if(g_str_equal(name, "openfolder")) {
+        showInFileManager(self->folder()->cleanPath());
+    }
+
+    if(g_str_equal(name, "logout")) {
+        self->folder()->accountState()->signOutByUi();
+    }
+
+    if(g_str_equal(name, "quit")) {
+        qApp->quit();
+    }
+}
+
+static void
+activate_action_openrecentfile (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+{
+    (void)(action);
+    (void)(parameter);
+    CloudProviderWrapper *self = static_cast<CloudProviderWrapper*>(user_data);
+    QDesktopServices::openUrl(self->folder()->accountState()->account()->url());
+}
+
+static void
+activate_action_pause (GSimpleAction *action,
+                 GVariant      *parameter,
+                 gpointer       user_data)
+{
+  GVariant *old_state, *new_state;
+
+  old_state = g_action_get_state (G_ACTION (action));
+  new_state = g_variant_new_boolean (!g_variant_get_boolean (old_state));
+
+  /*g_print ("Toggle action %s activated, state changes from %d to %d\n",
+           g_action_get_name (G_ACTION (action)),
+           g_variant_get_boolean (old_state),
+           g_variant_get_boolean (new_state));*/
+
+  g_simple_action_set_state (action, new_state);
+  g_variant_unref (old_state);
+}
+
+static GActionEntry actions[] = {
+    { "openwebsite",  activate_action_open, NULL, NULL, NULL, {0,0,0}},
+    { "quit",  activate_action_open, NULL, NULL, NULL, {0,0,0}},
+    { "logout",  activate_action_open, NULL, NULL, NULL, {0,0,0}},
+    { "openfolder",  activate_action_open, NULL, NULL, NULL, {0,0,0}},
+    { "openhelp",  activate_action_open, NULL, NULL, NULL, {0,0,0}},
+    { "opensettings",  activate_action_open, NULL, NULL, NULL, {0,0,0}},
+    { "openrecentfile",  activate_action_openrecentfile, "s", NULL, NULL, {0,0,0}},
+    { "pause",  activate_action_pause, NULL, "false", NULL, {0,0,0}},
+
+};
+
+GActionGroup* CloudProviderWrapper::getActionGroup()
+{
+    GSimpleActionGroup *group;
+    group = g_simple_action_group_new ();
+    g_action_map_add_action_entries (G_ACTION_MAP (group),
+                                     actions,
+                                     G_N_ELEMENTS (actions), this);
+    return G_ACTION_GROUP (group);
+}

--- a/src/gui/cloudproviders/cloudproviderwrapper.h
+++ b/src/gui/cloudproviders/cloudproviderwrapper.h
@@ -4,11 +4,11 @@
 #include <QObject>
 #include "folderman.h"
 
-// Forward declaration required since gio header files interfere with QObject headers
-struct _CloudProvider;
-typedef _CloudProvider CloudProvider;
-struct _CloudProviderAccount1;
-typedef _CloudProviderAccount1 CloudProviderAccount1;
+/* Forward declaration required since gio header files interfere with QObject headers */
+struct _CloudProviderExporter;
+typedef _CloudProviderExporter CloudProviderExporter;
+struct _CloudProviderAccountExporter;
+typedef _CloudProviderAccountExporter CloudProviderAccountExporter;
 struct _GMenuModel;
 typedef _GMenuModel GMenuModel;
 struct _GMenu;
@@ -25,15 +25,16 @@ class CloudProviderWrapper : public QObject
 {
     Q_OBJECT
 public:
-    explicit CloudProviderWrapper(QObject *parent = nullptr, OCC::Folder *folder = nullptr, CloudProvider* cloudprovider = nullptr);
+    explicit CloudProviderWrapper(QObject *parent = nullptr, Folder *folder = nullptr, CloudProviderExporter* cloudprovider = nullptr);
     ~CloudProviderWrapper();
     gchar* accountName();
-    OCC::Folder* folder();
+    CloudProviderAccountExporter* accountExporter();
+    Folder* folder();
     GMenuModel* getMenuModel();
     GActionGroup* getActionGroup();
-    gpointer name;
+    gchar* name;
     uint status;
-    gpointer path;
+    gchar* path;
     gpointer icon;
     gchar* statusText();
 signals:
@@ -48,10 +49,10 @@ public slots:
     void slotSyncPausedChanged(Folder*, bool);
 
 private:
-    OCC::Folder *_folder;
-    CloudProvider *_cloudProvider;
+    Folder *_folder;
+    CloudProviderExporter *_cloudProvider;
     gchar *_accountName;
-    CloudProviderAccount1 *_cloudProviderAccount1;
+    CloudProviderAccountExporter *_cloudProviderAccount1;
     uint _syncStatus;
     QList<QPair<QString, QString>> *_recentlyChanged;
     QString _statusText;

--- a/src/gui/cloudproviders/cloudproviderwrapper.h
+++ b/src/gui/cloudproviders/cloudproviderwrapper.h
@@ -15,6 +15,7 @@ struct _GActionGroup;
 typedef _GActionGroup GActionGroup;
 typedef char gchar;
 typedef void* gpointer;
+typedef unsigned int guint;
 
 using namespace OCC;
 
@@ -23,6 +24,7 @@ class CloudProviderWrapper : public QObject
     Q_OBJECT
 public:
     explicit CloudProviderWrapper(QObject *parent = nullptr, OCC::Folder *folder = nullptr, CloudProvider* cloudprovider = nullptr);
+    ~CloudProviderWrapper();
     gchar* accountName();
     OCC::Folder* folder();
     GMenuModel* getMenuModel();
@@ -41,6 +43,8 @@ public slots:
     void slotSyncFinished(const SyncResult &);
     void slotUpdateProgress(const QString &folder, const ProgressInfo &progress);
     void slotStatusUpdateIdle();
+    void slotSyncPausedChanged(Folder*, bool);
+
 private:
     OCC::Folder *_folder;
     CloudProvider *_cloudProvider;
@@ -49,6 +53,9 @@ private:
     uint _syncStatus;
     QList<QString> *_recentlyChanged;
     QString _statusText;
+    bool paused;
+    guint export_id_menu;
+    guint export_id_actions;
 };
 
 #endif // CLOUDPROVIDER_H

--- a/src/gui/cloudproviders/cloudproviderwrapper.h
+++ b/src/gui/cloudproviders/cloudproviderwrapper.h
@@ -11,6 +11,8 @@ struct _CloudProviderAccount1;
 typedef _CloudProviderAccount1 CloudProviderAccount1;
 struct _GMenuModel;
 typedef _GMenuModel GMenuModel;
+struct _GMenu;
+typedef _GMenu GMenu;
 struct _GActionGroup;
 typedef _GActionGroup GActionGroup;
 typedef char gchar;
@@ -51,11 +53,12 @@ private:
     gchar *_accountName;
     CloudProviderAccount1 *_cloudProviderAccount1;
     uint _syncStatus;
-    QList<QString> *_recentlyChanged;
+    QList<QPair<QString, QString>> *_recentlyChanged;
     QString _statusText;
     bool paused;
-    guint export_id_menu;
-    guint export_id_actions;
+    GMenuModel* _menuModel;
+    GMenu* mainMenu = NULL;
+    GMenu* recentMenu = NULL;
 };
 
 #endif // CLOUDPROVIDER_H

--- a/src/gui/cloudproviders/cloudproviderwrapper.h
+++ b/src/gui/cloudproviders/cloudproviderwrapper.h
@@ -1,0 +1,54 @@
+#ifndef CLOUDPROVIDER_H
+#define CLOUDPROVIDER_H
+
+#include <QObject>
+#include "folderman.h"
+
+// Forward declaration required since gio header files interfere with QObject headers
+struct _CloudProvider;
+typedef _CloudProvider CloudProvider;
+struct _CloudProviderAccount1;
+typedef _CloudProviderAccount1 CloudProviderAccount1;
+struct _GMenuModel;
+typedef _GMenuModel GMenuModel;
+struct _GActionGroup;
+typedef _GActionGroup GActionGroup;
+typedef char gchar;
+typedef void* gpointer;
+
+using namespace OCC;
+
+class CloudProviderWrapper : public QObject
+{
+    Q_OBJECT
+public:
+    explicit CloudProviderWrapper(QObject *parent = nullptr, OCC::Folder *folder = nullptr, CloudProvider* cloudprovider = nullptr);
+    gchar* accountName();
+    OCC::Folder* folder();
+    GMenuModel* getMenuModel();
+    GActionGroup* getActionGroup();
+    gpointer name;
+    uint status;
+    gpointer path;
+    gpointer icon;
+    gchar* statusText();
+signals:
+    void CloudProviderChanged();
+
+public slots:
+    void slotCloudProviderChanged();
+    void slotSyncStarted();
+    void slotSyncFinished(const SyncResult &);
+    void slotUpdateProgress(const QString &folder, const ProgressInfo &progress);
+    void slotStatusUpdateIdle();
+private:
+    OCC::Folder *_folder;
+    CloudProvider *_cloudProvider;
+    gchar *_accountName;
+    CloudProviderAccount1 *_cloudProviderAccount1;
+    uint _syncStatus;
+    QList<QString> *_recentlyChanged;
+    QString _statusText;
+};
+
+#endif // CLOUDPROVIDER_H

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -800,6 +800,7 @@ void FolderMan::slotRemoveFoldersForAccount(AccountState *accountState)
     foreach (const auto &f, foldersToRemove) {
         removeFolder(f);
     }
+    emit folderListChanged(_folderMap);
 }
 
 void FolderMan::slotForwardFolderSyncStateChange()

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -26,6 +26,7 @@
 #include <QSignalMapper>
 #include <QSize>
 #include <QTimer>
+#include <QDBusConnection>
 
 namespace OCC {
 
@@ -53,6 +54,10 @@ public:
     static void raiseDialog(QWidget *raiseWidget);
     static QSize settingsDialogSize() { return QSize(800, 500); }
     void setupOverlayIcons();
+#ifdef WITH_LIBCLOUDPROVIDERS
+    void setupCloudProviders();
+    bool cloudProviderApiAvailable();
+#endif
 
     /// Whether the tray menu is visible
     bool contextMenuVisible() const;
@@ -124,6 +129,8 @@ private:
     // Manually tracking whether the context menu is visible, but only works
     // on OSX because aboutToHide is not reliable everywhere.
     bool _contextMenuVisibleOsx;
+
+    QDBusConnection _bus;
 
     QMenu *_recentActionsMenu;
     QVector<QMenu *> _accountMenus;

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -102,6 +102,15 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     _actionGroup = new QActionGroup(this);
     _actionGroup->setExclusive(true);
 
+
+    addAccountAction = createColorAwareAction(QLatin1String(":/client/resources/account.png"), tr("Add account"));
+    _toolBar->addAction(addAccountAction);
+    addAccountAction->setCheckable(false);
+    if (!Theme::instance()->multiAccount()) {
+        addAccountAction->setVisible(false);
+    }
+    connect(addAccountAction, SIGNAL(triggered(bool)), _gui, SLOT(slotNewAccountWizard()));
+
     // Note: all the actions have a '\n' because the account name is in two lines and
     // all buttons must have the same size in order to keep a good layout
     _activityAction = createColorAwareAction(QLatin1String(":/client/resources/activity.png"), tr("Activity"));
@@ -200,7 +209,7 @@ void SettingsDialog::showFirstPage()
 {
     QList<QAction *> actions = _toolBar->actions();
     if (!actions.empty()) {
-        actions.first()->trigger();
+        actions.at(1)->trigger();
     }
 }
 
@@ -246,6 +255,8 @@ void SettingsDialog::accountAdded(AccountState *s)
     _actionGroup->addAction(accountAction);
     _actionGroupWidgets.insert(accountAction, accountSettings);
     _actionForAccount.insert(s->account().data(), accountAction);
+
+    addAccountAction->setVisible(false);
 
     connect(accountSettings, SIGNAL(folderChanged()), _gui, SLOT(slotFoldersChanged()));
     connect(accountSettings, SIGNAL(openFolderAlias(const QString &)),
@@ -301,6 +312,9 @@ void SettingsDialog::accountRemoved(AccountState *s)
     // configured.
     if (AccountManager::instance()->accounts().isEmpty()) {
         hide();
+        if (!Theme::instance()->multiAccount()) {
+            addAccountAction->setVisible(true);
+        }
     }
 }
 

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -83,6 +83,7 @@ private:
     // Maps the actions from the action group to the corresponding widgets
     QHash<QAction *, QWidget *> _actionGroupWidgets;
 
+    QAction *addAccountAction;
     // Maps the action in the dialog to their according account. Needed in
     // case the account avatar changes
     QHash<Account *, QAction *> _actionForAccount;


### PR DESCRIPTION
Example integration in nautilus:
![2017-08-10-123509_960x396_scrot](https://user-images.githubusercontent.com/3404133/29166931-aab3c9b2-7dc8-11e7-8a73-925cdd49e9e7.png)
![2017-08-10-123647_960x396_scrot](https://user-images.githubusercontent.com/3404133/29166934-b063c934-7dc8-11e7-8002-421b84a15e4b.png)
![2017-08-10-123623_960x396_scrot](https://user-images.githubusercontent.com/3404133/29166936-b1cbe7a2-7dc8-11e7-9ac6-96342fa7d414.png)


ToDo:
- [x] Remove custom jhbuild path from FindLibcloudproviders.cmake
- [ ] Add cloudproviders support to CI
- [x] Show recently changed files in menu
- [x] enable pausing accounts from menu